### PR TITLE
Resolve potential memory leaks.

### DIFF
--- a/dot_env.h
+++ b/dot_env.h
@@ -113,7 +113,7 @@ env_load(const char *path, const int overwrite)
             continue;
         }
 
-        char *token = strdup(line);
+        char *token = line;
         char *key = strsep(&token, SEPERATOR);
         char *value = strsep(&token, NEW_LINE);
 
@@ -121,6 +121,7 @@ env_load(const char *path, const int overwrite)
 
         if (setenv(key, trim_whitespace(value), overwrite) != 0) {
             fclose(f);
+            free(line);
             return 1;
         }
     }


### PR DESCRIPTION
* Leak occurs from the use of `strdup()` and not freeing the result. Additionally, as `setenv()` copies the input string, it is not needed.
* Leak occurs if `setenv()` fails.

Compile: `gcc -O0 -g example/main.c`

<details>
<summary>.env file</summary>
<pre>
SERVER=127.0.0.1
</pre>
</details>

Valigrind/Memcheck results:
<details>
<summary>Before changes</summary>
<pre>
> valgrind --leak-check=full -s ./a.out
...
==4497== HEAP SUMMARY:
==4497==     in use at exit: 18 bytes in 1 blocks
==4497==   total heap usage: 8 allocs, 7 frees, 6,051 bytes allocated
==4497==
==4497== 18 bytes in 1 blocks are definitely lost in loss record 1 of 1
==4497==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==4497==    by 0x48E0E4A: strdup (strdup.c:42)
==4497==    by 0x109447: env_load (dot_env.h:116)
==4497==    by 0x109535: main (main.c:8)
==4497==
==4497== LEAK SUMMARY:
==4497==    definitely lost: 18 bytes in 1 blocks
==4497==    indirectly lost: 0 bytes in 0 blocks
==4497==      possibly lost: 0 bytes in 0 blocks
==4497==    still reachable: 0 bytes in 0 blocks
==4497==         suppressed: 0 bytes in 0 blocks
==4497==
==4497== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
</pre>
</details>

<details>
<summary>After changes</summary>
<pre>
> valgrind --leak-check=full -s ./a.out
...
==3950== HEAP SUMMARY:
==3950==     in use at exit: 0 bytes in 0 blocks
==3950==   total heap usage: 4 allocs, 4 frees, 8,784 bytes allocated
==3950==
==3950== All heap blocks were freed -- no leaks are possible
==3950==
==3950== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
</pre>
</details>